### PR TITLE
README: update documentation badge and add license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # aec
 
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/dmorikuni/aec)](https://pkg.go.dev/github.com/morikuni/aec)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/morikuni/aec/blob/master/LICENSE)
 
 Go wrapper for ANSI escape code.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aec
 
-[![GoDoc](https://godoc.org/github.com/morikuni/aec?status.svg)](https://godoc.org/github.com/morikuni/aec)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/dmorikuni/aec)](https://pkg.go.dev/github.com/morikuni/aec)
 
 Go wrapper for ANSI escape code.
 


### PR DESCRIPTION
The badge was still using the old "godoc.org" domain.