### PR TITLE
remove redundant init functions, update godoc, and add some consts

### DIFF
--- a/aec.go
+++ b/aec.go
@@ -21,6 +21,31 @@ var EraseModes = struct {
 	All:  2,
 }
 
+// EraseDisplayMode is the parameter for the ED (Erase in Display, CSI Ps J)
+// control sequence. It defines which portion of the display should be erased.
+//
+// This is an alias of [EraseMode] for backward compatibility.
+type EraseDisplayMode = EraseMode
+
+const (
+	EraseDisplayTail       EraseDisplayMode = 0 // erase from cursor to end of display
+	EraseDisplayHead       EraseDisplayMode = 1 // erase from start of display to cursor
+	EraseDisplayAll        EraseDisplayMode = 2 // erase entire display
+	EraseDisplaySavedLines EraseDisplayMode = 3 // erase saved lines (scrollback), non-standard but widely supported
+)
+
+// EraseLineMode is the parameter for the EL (Erase in Line, CSI Ps K)
+// control sequence. It defines which portion of the current line should be erased.
+//
+// This is an alias of [EraseMode] for backward compatibility.
+type EraseLineMode = EraseMode
+
+const (
+	EraseLineTail EraseLineMode = 0 // erase from cursor to end of line
+	EraseLineHead EraseLineMode = 1 // erase from start of line to cursor
+	EraseLineAll  EraseLineMode = 2 // erase entire line
+)
+
 // Cursor control and reporting sequences.
 //
 // Includes CSI sequences defined by ECMA-48 / ISO 6429, DEC private modes,
@@ -99,13 +124,13 @@ func Position(row, col uint) ANSI {
 	return newAnsi(fmt.Sprintf(Esc+"%d;%dH", row, col))
 }
 
-// EraseDisplay erases the display using the given EraseMode (ED).
-func EraseDisplay(m EraseMode) ANSI {
+// EraseDisplay erases the display using the given [EraseDisplayMode] (ED).
+func EraseDisplay(m EraseDisplayMode) ANSI {
 	return newAnsi(fmt.Sprintf(Esc+"%dJ", m))
 }
 
-// EraseLine erases the line using the given EraseMode (EL).
-func EraseLine(m EraseMode) ANSI {
+// EraseLine erases the line using the given [EraseLineMode] (EL).
+func EraseLine(m EraseLineMode) ANSI {
 	return newAnsi(fmt.Sprintf(Esc+"%dK", m))
 }
 

--- a/aec.go
+++ b/aec.go
@@ -42,7 +42,7 @@ var (
 	Report ANSI = newAnsi(esc + "6n")
 )
 
-// Up moves up the cursor.
+// Up moves the cursor up by n positions (CUU).
 func Up(n uint) ANSI {
 	if n == 0 {
 		return empty
@@ -50,7 +50,7 @@ func Up(n uint) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dA", n))
 }
 
-// Down moves down the cursor.
+// Down moves the cursor down by n positions (CUD).
 func Down(n uint) ANSI {
 	if n == 0 {
 		return empty
@@ -58,7 +58,7 @@ func Down(n uint) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dB", n))
 }
 
-// Right moves right the cursor.
+// Right moves the cursor right by n positions (CUF).
 func Right(n uint) ANSI {
 	if n == 0 {
 		return empty
@@ -66,7 +66,7 @@ func Right(n uint) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dC", n))
 }
 
-// Left moves left the cursor.
+// Left moves the cursor left by n positions (CUB).
 func Left(n uint) ANSI {
 	if n == 0 {
 		return empty
@@ -74,7 +74,7 @@ func Left(n uint) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dD", n))
 }
 
-// NextLine moves down the cursor to head of a line.
+// NextLine moves the cursor down n lines and to the beginning of the line (CNL).
 func NextLine(n uint) ANSI {
 	if n == 0 {
 		return empty
@@ -82,7 +82,7 @@ func NextLine(n uint) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dE", n))
 }
 
-// PreviousLine moves up the cursor to head of a line.
+// PreviousLine moves the cursor up n lines and to the beginning of the line (CPL).
 func PreviousLine(n uint) ANSI {
 	if n == 0 {
 		return empty
@@ -90,27 +90,27 @@ func PreviousLine(n uint) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dF", n))
 }
 
-// Column set the cursor position to a given column.
+// Column sets the cursor position to a given column (CHA).
 func Column(col uint) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dG", col))
 }
 
-// Position set the cursor position to a given absolute position.
+// Position sets the cursor position to a given absolute position (CUP).
 func Position(row, col uint) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%d;%dH", row, col))
 }
 
-// EraseDisplay erases display by given EraseMode.
+// EraseDisplay erases the display using the given EraseMode (ED).
 func EraseDisplay(m EraseMode) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dJ", m))
 }
 
-// EraseLine erases lines by given EraseMode.
+// EraseLine erases the line using the given EraseMode (EL).
 func EraseLine(m EraseMode) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dK", m))
 }
 
-// ScrollUp scrolls up the page.
+// ScrollUp scrolls the display up by n lines (SU).
 func ScrollUp(n int) ANSI {
 	if n == 0 {
 		return empty
@@ -118,7 +118,7 @@ func ScrollUp(n int) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dS", n))
 }
 
-// ScrollDown scrolls down the page.
+// ScrollDown scrolls the display down by n lines (SD).
 func ScrollDown(n int) ANSI {
 	if n == 0 {
 		return empty

--- a/aec.go
+++ b/aec.go
@@ -5,33 +5,41 @@ import "fmt"
 // EraseMode is listed in a variable EraseModes.
 type EraseMode uint
 
+// EraseModes is a list of EraseMode.
+var EraseModes = struct {
+	// All erase all.
+	All EraseMode
+
+	// Head erase to head.
+	Head EraseMode
+
+	// Tail erase to tail.
+	Tail EraseMode
+}{
+	Tail: 0,
+	Head: 1,
+	All:  2,
+}
+
 var (
-	// EraseModes is a list of EraseMode.
-	EraseModes struct {
-		// All erase all.
-		All EraseMode
+	// Save saves the cursor position. It uses both SCO ("ESC[s") and DEC
+	// ("ESC7") sequences as those were never standardized as part of the
+	// ANSI.
+	Save ANSI = newAnsi(esc + "s" + "\x1b7")
 
-		// Head erase to head.
-		Head EraseMode
-
-		// Tail erase to tail.
-		Tail EraseMode
-	}
-
-	// Save saves the cursor position.
-	Save ANSI
-
-	// Restore restores the cursor position.
-	Restore ANSI
+	// Restore restores the cursor position. It uses both SCO ("ESC[u") and
+	// DEC ("ESC8") sequences as those were never standardized as part of
+	// the ANSI.
+	Restore ANSI = newAnsi(esc + "u" + "\x1b8")
 
 	// Hide hides the cursor.
-	Hide ANSI
+	Hide ANSI = newAnsi(esc + "?25l")
 
 	// Show shows the cursor.
-	Show ANSI
+	Show ANSI = newAnsi(esc + "?25h")
 
 	// Report reports the cursor position.
-	Report ANSI
+	Report ANSI = newAnsi(esc + "6n")
 )
 
 // Up moves up the cursor.
@@ -116,24 +124,4 @@ func ScrollDown(n int) ANSI {
 		return empty
 	}
 	return newAnsi(fmt.Sprintf(esc+"%dT", n))
-}
-
-func init() {
-	EraseModes = struct {
-		All  EraseMode
-		Head EraseMode
-		Tail EraseMode
-	}{
-		Tail: 0,
-		Head: 1,
-		All:  2,
-	}
-
-	// Save use both SCO (ESC[s) and DEC (ESC7) sequences as those were never standardised as part of the ANSI
-	Save = newAnsi(esc + "s" + "\x1b7")
-	// Restore use both SCO (ESC[u) and DEC (ESC8) and DEC sequences as those were never standardised as part of the ANSI
-	Restore = newAnsi(esc + "u" + "\x1b8")
-	Hide = newAnsi(esc + "?25l")
-	Show = newAnsi(esc + "?25h")
-	Report = newAnsi(esc + "6n")
 }

--- a/aec.go
+++ b/aec.go
@@ -21,25 +21,24 @@ var EraseModes = struct {
 	All:  2,
 }
 
+// Cursor control and reporting sequences.
+//
+// Includes CSI sequences defined by ECMA-48 / ISO 6429, DEC private modes,
+// and legacy DEC/SCO save and restore sequences.
 var (
-	// Save saves the cursor position. It uses both SCO ("ESC[s") and DEC
-	// ("ESC7") sequences as those were never standardized as part of the
-	// ANSI.
-	Save ANSI = newAnsi(esc + "s" + "\x1b7")
+	// Cursor save and restore sequences.
+	//
+	// These use both SCO ("ESC[s"/"ESC[u") and DEC ("ESC 7"/"ESC 8")
+	// sequences for compatibility. They are not standardized in ECMA-48.
+	Save    ANSI = newAnsi(esc + "s" + "\x1b7") // saves the cursor position.
+	Restore ANSI = newAnsi(esc + "u" + "\x1b8") // restores the cursor position.
 
-	// Restore restores the cursor position. It uses both SCO ("ESC[u") and
-	// DEC ("ESC8") sequences as those were never standardized as part of
-	// the ANSI.
-	Restore ANSI = newAnsi(esc + "u" + "\x1b8")
+	// Cursor visibility (DEC private mode 25).
+	Hide ANSI = newAnsi(esc + "?25l") // hides the cursor.
+	Show ANSI = newAnsi(esc + "?25h") // shows the cursor.
 
-	// Hide hides the cursor.
-	Hide ANSI = newAnsi(esc + "?25l")
-
-	// Show shows the cursor.
-	Show ANSI = newAnsi(esc + "?25h")
-
-	// Report reports the cursor position.
-	Report ANSI = newAnsi(esc + "6n")
+	// Cursor position report (DSR 6, ECMA-48).
+	Report ANSI = newAnsi(esc + "6n") // requests the cursor position.
 )
 
 // Up moves the cursor up by n positions (CUU).

--- a/aec.go
+++ b/aec.go
@@ -30,15 +30,15 @@ var (
 	//
 	// These use both SCO ("ESC[s"/"ESC[u") and DEC ("ESC 7"/"ESC 8")
 	// sequences for compatibility. They are not standardized in ECMA-48.
-	Save    ANSI = newAnsi(esc + "s" + "\x1b7") // saves the cursor position.
-	Restore ANSI = newAnsi(esc + "u" + "\x1b8") // restores the cursor position.
+	Save    ANSI = newAnsi(Esc + "s" + "\x1b7") // saves the cursor position.
+	Restore ANSI = newAnsi(Esc + "u" + "\x1b8") // restores the cursor position.
 
 	// Cursor visibility (DEC private mode 25).
-	Hide ANSI = newAnsi(esc + "?25l") // hides the cursor.
-	Show ANSI = newAnsi(esc + "?25h") // shows the cursor.
+	Hide ANSI = newAnsi(Esc + "?25l") // hides the cursor.
+	Show ANSI = newAnsi(Esc + "?25h") // shows the cursor.
 
 	// Cursor position report (DSR 6, ECMA-48).
-	Report ANSI = newAnsi(esc + "6n") // requests the cursor position.
+	Report ANSI = newAnsi(Esc + "6n") // requests the cursor position.
 )
 
 // Up moves the cursor up by n positions (CUU).
@@ -46,7 +46,7 @@ func Up(n uint) ANSI {
 	if n == 0 {
 		return empty
 	}
-	return newAnsi(fmt.Sprintf(esc+"%dA", n))
+	return newAnsi(fmt.Sprintf(Esc+"%dA", n))
 }
 
 // Down moves the cursor down by n positions (CUD).
@@ -54,7 +54,7 @@ func Down(n uint) ANSI {
 	if n == 0 {
 		return empty
 	}
-	return newAnsi(fmt.Sprintf(esc+"%dB", n))
+	return newAnsi(fmt.Sprintf(Esc+"%dB", n))
 }
 
 // Right moves the cursor right by n positions (CUF).
@@ -62,7 +62,7 @@ func Right(n uint) ANSI {
 	if n == 0 {
 		return empty
 	}
-	return newAnsi(fmt.Sprintf(esc+"%dC", n))
+	return newAnsi(fmt.Sprintf(Esc+"%dC", n))
 }
 
 // Left moves the cursor left by n positions (CUB).
@@ -70,7 +70,7 @@ func Left(n uint) ANSI {
 	if n == 0 {
 		return empty
 	}
-	return newAnsi(fmt.Sprintf(esc+"%dD", n))
+	return newAnsi(fmt.Sprintf(Esc+"%dD", n))
 }
 
 // NextLine moves the cursor down n lines and to the beginning of the line (CNL).
@@ -78,7 +78,7 @@ func NextLine(n uint) ANSI {
 	if n == 0 {
 		return empty
 	}
-	return newAnsi(fmt.Sprintf(esc+"%dE", n))
+	return newAnsi(fmt.Sprintf(Esc+"%dE", n))
 }
 
 // PreviousLine moves the cursor up n lines and to the beginning of the line (CPL).
@@ -86,27 +86,27 @@ func PreviousLine(n uint) ANSI {
 	if n == 0 {
 		return empty
 	}
-	return newAnsi(fmt.Sprintf(esc+"%dF", n))
+	return newAnsi(fmt.Sprintf(Esc+"%dF", n))
 }
 
 // Column sets the cursor position to a given column (CHA).
 func Column(col uint) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"%dG", col))
+	return newAnsi(fmt.Sprintf(Esc+"%dG", col))
 }
 
 // Position sets the cursor position to a given absolute position (CUP).
 func Position(row, col uint) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"%d;%dH", row, col))
+	return newAnsi(fmt.Sprintf(Esc+"%d;%dH", row, col))
 }
 
 // EraseDisplay erases the display using the given EraseMode (ED).
 func EraseDisplay(m EraseMode) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"%dJ", m))
+	return newAnsi(fmt.Sprintf(Esc+"%dJ", m))
 }
 
 // EraseLine erases the line using the given EraseMode (EL).
 func EraseLine(m EraseMode) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"%dK", m))
+	return newAnsi(fmt.Sprintf(Esc+"%dK", m))
 }
 
 // ScrollUp scrolls the display up by n lines (SU).
@@ -114,7 +114,7 @@ func ScrollUp(n int) ANSI {
 	if n == 0 {
 		return empty
 	}
-	return newAnsi(fmt.Sprintf(esc+"%dS", n))
+	return newAnsi(fmt.Sprintf(Esc+"%dS", n))
 }
 
 // ScrollDown scrolls the display down by n lines (SD).
@@ -122,5 +122,5 @@ func ScrollDown(n int) ANSI {
 	if n == 0 {
 		return empty
 	}
-	return newAnsi(fmt.Sprintf(esc+"%dT", n))
+	return newAnsi(fmt.Sprintf(Esc+"%dT", n))
 }

--- a/ansi.go
+++ b/ansi.go
@@ -5,24 +5,26 @@ import (
 	"strings"
 )
 
+// esc is the ANSI escape sequence introducer (ESC).
 const esc = "\x1b["
 
-// Reset resets SGR effect.
-const Reset string = "\x1b[0m"
+// Reset clears all SGR attributes.
+const Reset = "\x1b[0m"
 
 var empty = newAnsi("")
 
-// ANSI represents ANSI escape code.
+// ANSI represents an ANSI escape sequence (SGR).
 type ANSI interface {
 	fmt.Stringer
 
-	// With adapts given ANSIs.
+	// With returns a new sequence composed with the given ones.
 	With(...ANSI) ANSI
 
-	// Apply wraps given string in ANSI.
+	// Apply wraps s with the sequence and appends a reset.
 	Apply(string) string
 }
 
+// ansiImpl represents an ANSI escape sequence (SGR).
 type ansiImpl string
 
 func newAnsi(s string) *ansiImpl {
@@ -30,19 +32,22 @@ func newAnsi(s string) *ansiImpl {
 	return &r
 }
 
+// With returns a new ANSI sequence composed of this and the provided ones.
 func (a *ansiImpl) With(ansi ...ANSI) ANSI {
 	return concat(append([]ANSI{a}, ansi...))
 }
 
+// Apply wraps s with the ANSI sequence and a reset.
 func (a *ansiImpl) Apply(s string) string {
 	return a.String() + s + Reset
 }
 
+// String returns the ANSI escape sequence.
 func (a *ansiImpl) String() string {
 	return string(*a)
 }
 
-// Apply wraps given string in ANSIs.
+// Apply wraps s with all provided ANSI sequences and a reset.
 func Apply(s string, ansi ...ANSI) string {
 	if len(ansi) == 0 {
 		return s

--- a/ansi.go
+++ b/ansi.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 )
 
-// esc is the ANSI escape sequence introducer (ESC).
-const esc = "\x1b["
+// Esc is the ANSI escape sequence introducer (ESC).
+const Esc = "\x1b["
 
 // Reset clears all SGR attributes.
 const Reset = "\x1b[0m"

--- a/builder.go
+++ b/builder.go
@@ -74,12 +74,12 @@ func (builder *Builder) Position(row, col uint) *Builder {
 // Erasing and scrolling.
 
 // EraseDisplay erases the display using the given mode.
-func (builder *Builder) EraseDisplay(m EraseMode) *Builder {
+func (builder *Builder) EraseDisplay(m EraseDisplayMode) *Builder {
 	return builder.With(EraseDisplay(m))
 }
 
 // EraseLine erases the current line using the given mode.
-func (builder *Builder) EraseLine(m EraseMode) *Builder {
+func (builder *Builder) EraseLine(m EraseLineMode) *Builder {
 	return builder.With(EraseLine(m))
 }
 

--- a/builder.go
+++ b/builder.go
@@ -1,384 +1,430 @@
 package aec
 
-// Builder is a lightweight syntax to construct customized ANSI.
+// Builder incrementally composes ANSI escape sequences.
+//
+// Builder is immutable: methods do not modify the receiver, but return a new
+// Builder with the requested sequence appended. This allows chaining and
+// branching from any intermediate state:
+//
+//	b1 := NewBuilder().RedF()
+//	b2 := b1.Bold() // b1 is unchanged
+//
+// The resulting ANSI sequence can be obtained via b.ANSI or b.String().
 type Builder struct {
 	ANSI ANSI
 }
 
-// EmptyBuilder is an initialized Builder.
+// EmptyBuilder is a Builder with no sequences.
 var EmptyBuilder = &Builder{empty}
 
-// NewBuilder creates a Builder from existing ANSI.
+// NewBuilder returns a new Builder containing the given sequences.
 func NewBuilder(a ...ANSI) *Builder {
 	return &Builder{concat(a)}
 }
 
-// With is a syntax for With.
+// With returns a new Builder with the given sequences appended.
 func (builder *Builder) With(a ...ANSI) *Builder {
 	return NewBuilder(builder.ANSI.With(a...))
 }
 
-// Up is a syntax for Up.
+// Cursor movement sequences.
+//
+// These methods reposition the cursor without modifying text.
+
+// Up moves the cursor up by n lines.
 func (builder *Builder) Up(n uint) *Builder {
 	return builder.With(Up(n))
 }
 
-// Down is a syntax for Down.
+// Down moves the cursor down by n lines.
 func (builder *Builder) Down(n uint) *Builder {
 	return builder.With(Down(n))
 }
 
-// Right is a syntax for Right.
+// Right moves the cursor right by n columns.
 func (builder *Builder) Right(n uint) *Builder {
 	return builder.With(Right(n))
 }
 
-// Left is a syntax for Left.
+// Left moves the cursor left by n columns.
 func (builder *Builder) Left(n uint) *Builder {
 	return builder.With(Left(n))
 }
 
-// NextLine is a syntax for NextLine.
+// NextLine moves the cursor down n lines and to column 1.
 func (builder *Builder) NextLine(n uint) *Builder {
 	return builder.With(NextLine(n))
 }
 
-// PreviousLine is a syntax for PreviousLine.
+// PreviousLine moves the cursor up n lines and to column 1.
 func (builder *Builder) PreviousLine(n uint) *Builder {
 	return builder.With(PreviousLine(n))
 }
 
-// Column is a syntax for Column.
+// Column moves the cursor to the given column.
 func (builder *Builder) Column(col uint) *Builder {
 	return builder.With(Column(col))
 }
 
-// Position is a syntax for Position.
+// Position moves the cursor to the given row and column.
 func (builder *Builder) Position(row, col uint) *Builder {
 	return builder.With(Position(row, col))
 }
 
-// EraseDisplay is a syntax for EraseDisplay.
+// Erasing and scrolling.
+
+// EraseDisplay erases the display using the given mode.
 func (builder *Builder) EraseDisplay(m EraseMode) *Builder {
 	return builder.With(EraseDisplay(m))
 }
 
-// EraseLine is a syntax for EraseLine.
+// EraseLine erases the current line using the given mode.
 func (builder *Builder) EraseLine(m EraseMode) *Builder {
 	return builder.With(EraseLine(m))
 }
 
-// ScrollUp is a syntax for ScrollUp.
+// ScrollUp scrolls the display up by n lines.
 func (builder *Builder) ScrollUp(n int) *Builder {
 	return builder.With(ScrollUp(n))
 }
 
-// ScrollDown is a syntax for ScrollDown.
+// ScrollDown scrolls the display down by n lines.
 func (builder *Builder) ScrollDown(n int) *Builder {
 	return builder.With(ScrollDown(n))
 }
 
-// Save is a syntax for Save.
+// Cursor control and reporting sequences.
+//
+// These methods control cursor state or request cursor information,
+// including CSI sequences (ECMA-48), DEC private modes, and legacy
+// DEC/SCO save and restore sequences.
+
+// Save saves the cursor position.
 func (builder *Builder) Save() *Builder {
 	return builder.With(Save)
 }
 
-// Restore is a syntax for Restore.
+// Restore restores the cursor position.
 func (builder *Builder) Restore() *Builder {
 	return builder.With(Restore)
 }
 
-// Hide is a syntax for Hide.
+// Hide hides the cursor.
 func (builder *Builder) Hide() *Builder {
 	return builder.With(Hide)
 }
 
-// Show is a syntax for Show.
+// Show shows the cursor.
 func (builder *Builder) Show() *Builder {
 	return builder.With(Show)
 }
 
-// Report is a syntax for Report.
+// Report requests the cursor position.
 func (builder *Builder) Report() *Builder {
 	return builder.With(Report)
 }
 
-// Bold is a syntax for Bold.
+// Text styles and decorations.
+//
+// These methods modify text presentation (e.g., intensity, underline)
+// using SGR parameters defined by ECMA-48 / ISO 6429.
+
+// Bold enables bold or increased intensity.
 func (builder *Builder) Bold() *Builder {
 	return builder.With(Bold)
 }
 
-// Faint is a syntax for Faint.
+// Faint enables faint or decreased intensity.
 func (builder *Builder) Faint() *Builder {
 	return builder.With(Faint)
 }
 
-// Italic is a syntax for Italic.
+// Italic enables italic.
 func (builder *Builder) Italic() *Builder {
 	return builder.With(Italic)
 }
 
-// Underline is a syntax for Underline.
+// Underline enables underline.
 func (builder *Builder) Underline() *Builder {
 	return builder.With(Underline)
 }
 
-// BlinkSlow is a syntax for BlinkSlow.
+// BlinkSlow enables slow blinking.
 func (builder *Builder) BlinkSlow() *Builder {
 	return builder.With(BlinkSlow)
 }
 
-// BlinkRapid is a syntax for BlinkRapid.
+// BlinkRapid enables rapid blinking.
 func (builder *Builder) BlinkRapid() *Builder {
 	return builder.With(BlinkRapid)
 }
 
-// Inverse is a syntax for Inverse.
+// Inverse swaps foreground and background colors.
 func (builder *Builder) Inverse() *Builder {
 	return builder.With(Inverse)
 }
 
-// Conceal is a syntax for Conceal.
+// Conceal conceals the text.
 func (builder *Builder) Conceal() *Builder {
 	return builder.With(Conceal)
 }
 
-// CrossOut is a syntax for CrossOut.
+// CrossOut crosses out the text.
 func (builder *Builder) CrossOut() *Builder {
 	return builder.With(CrossOut)
 }
 
-// BlackF is a syntax for BlackF.
+// Foreground colors.
+//
+// These methods set the text (foreground) color using SGR parameters.
+// Color rendering depends on the terminal's palette.
+
+// BlackF sets the foreground color to black.
 func (builder *Builder) BlackF() *Builder {
 	return builder.With(BlackF)
 }
 
-// RedF is a syntax for RedF.
+// RedF sets the foreground color to red.
 func (builder *Builder) RedF() *Builder {
 	return builder.With(RedF)
 }
 
-// GreenF is a syntax for GreenF.
+// GreenF sets the foreground color to green.
 func (builder *Builder) GreenF() *Builder {
 	return builder.With(GreenF)
 }
 
-// YellowF is a syntax for YellowF.
+// YellowF sets the foreground color to yellow.
 func (builder *Builder) YellowF() *Builder {
 	return builder.With(YellowF)
 }
 
-// BlueF is a syntax for BlueF.
+// BlueF sets the foreground color to blue.
 func (builder *Builder) BlueF() *Builder {
 	return builder.With(BlueF)
 }
 
-// MagentaF is a syntax for MagentaF.
+// MagentaF sets the foreground color to magenta.
 func (builder *Builder) MagentaF() *Builder {
 	return builder.With(MagentaF)
 }
 
-// CyanF is a syntax for CyanF.
+// CyanF sets the foreground color to cyan.
 func (builder *Builder) CyanF() *Builder {
 	return builder.With(CyanF)
 }
 
-// WhiteF is a syntax for WhiteF.
+// WhiteF sets the foreground color to white.
 func (builder *Builder) WhiteF() *Builder {
 	return builder.With(WhiteF)
 }
 
-// DefaultF is a syntax for DefaultF.
+// DefaultF restores the default foreground color.
 func (builder *Builder) DefaultF() *Builder {
 	return builder.With(DefaultF)
 }
 
-// BlackB is a syntax for BlackB.
+// Background colors.
+//
+// These methods set the background color using SGR parameters.
+// Color rendering depends on the terminal's palette.
+
+// BlackB sets the background color to black.
 func (builder *Builder) BlackB() *Builder {
 	return builder.With(BlackB)
 }
 
-// RedB is a syntax for RedB.
+// RedB sets the background color to red.
 func (builder *Builder) RedB() *Builder {
 	return builder.With(RedB)
 }
 
-// GreenB is a syntax for GreenB.
+// GreenB sets the background color to green.
 func (builder *Builder) GreenB() *Builder {
 	return builder.With(GreenB)
 }
 
-// YellowB is a syntax for YellowB.
+// YellowB sets the background color to yellow.
 func (builder *Builder) YellowB() *Builder {
 	return builder.With(YellowB)
 }
 
-// BlueB is a syntax for BlueB.
+// BlueB sets the background color to blue.
 func (builder *Builder) BlueB() *Builder {
 	return builder.With(BlueB)
 }
 
-// MagentaB is a syntax for MagentaB.
+// MagentaB sets the background color to magenta.
 func (builder *Builder) MagentaB() *Builder {
 	return builder.With(MagentaB)
 }
 
-// CyanB is a syntax for CyanB.
+// CyanB sets the background color to cyan.
 func (builder *Builder) CyanB() *Builder {
 	return builder.With(CyanB)
 }
 
-// WhiteB is a syntax for WhiteB.
+// WhiteB sets the background color to white.
 func (builder *Builder) WhiteB() *Builder {
 	return builder.With(WhiteB)
 }
 
-// DefaultB is a syntax for DefaultB.
+// DefaultB restores the default background color.
 func (builder *Builder) DefaultB() *Builder {
 	return builder.With(DefaultB)
 }
 
-// Frame is a syntax for Frame.
+// Framing and overlines.
+//
+// These methods add framing or overline text decorations (SGR).
+
+// Frame enables framing.
 func (builder *Builder) Frame() *Builder {
 	return builder.With(Frame)
 }
 
-// Encircle is a syntax for Encircle.
+// Encircle enables encircling.
 func (builder *Builder) Encircle() *Builder {
 	return builder.With(Encircle)
 }
 
-// Overline is a syntax for Overline.
+// Overline enables overline.
 func (builder *Builder) Overline() *Builder {
 	return builder.With(Overline)
 }
 
-// LightBlackF is a syntax for LightBlueF.
+// Bright foreground colors.
+
+// LightBlackF sets the foreground color to bright black.
 func (builder *Builder) LightBlackF() *Builder {
 	return builder.With(LightBlackF)
 }
 
-// LightRedF is a syntax for LightRedF.
+// LightRedF sets the foreground color to bright red.
 func (builder *Builder) LightRedF() *Builder {
 	return builder.With(LightRedF)
 }
 
-// LightGreenF is a syntax for LightGreenF.
+// LightGreenF sets the foreground color to bright green.
 func (builder *Builder) LightGreenF() *Builder {
 	return builder.With(LightGreenF)
 }
 
-// LightYellowF is a syntax for LightYellowF.
+// LightYellowF sets the foreground color to bright yellow.
 func (builder *Builder) LightYellowF() *Builder {
 	return builder.With(LightYellowF)
 }
 
-// LightBlueF is a syntax for LightBlueF.
+// LightBlueF sets the foreground color to bright blue.
 func (builder *Builder) LightBlueF() *Builder {
 	return builder.With(LightBlueF)
 }
 
-// LightMagentaF is a syntax for LightMagentaF.
+// LightMagentaF sets the foreground color to bright magenta.
 func (builder *Builder) LightMagentaF() *Builder {
 	return builder.With(LightMagentaF)
 }
 
-// LightCyanF is a syntax for LightCyanF.
+// LightCyanF sets the foreground color to bright cyan.
 func (builder *Builder) LightCyanF() *Builder {
 	return builder.With(LightCyanF)
 }
 
-// LightWhiteF is a syntax for LightWhiteF.
+// LightWhiteF sets the foreground color to bright white.
 func (builder *Builder) LightWhiteF() *Builder {
 	return builder.With(LightWhiteF)
 }
 
-// LightBlackB is a syntax for LightBlackB.
+// Bright background colors.
+
+// LightBlackB sets the background color to bright black.
 func (builder *Builder) LightBlackB() *Builder {
 	return builder.With(LightBlackB)
 }
 
-// LightRedB is a syntax for LightRedB.
+// LightRedB sets the background color to bright red.
 func (builder *Builder) LightRedB() *Builder {
 	return builder.With(LightRedB)
 }
 
-// LightGreenB is a syntax for LightGreenB.
+// LightGreenB sets the background color to bright green.
 func (builder *Builder) LightGreenB() *Builder {
 	return builder.With(LightGreenB)
 }
 
-// LightYellowB is a syntax for LightYellowB.
+// LightYellowB sets the background color to bright yellow.
 func (builder *Builder) LightYellowB() *Builder {
 	return builder.With(LightYellowB)
 }
 
-// LightBlueB is a syntax for LightBlueB.
+// LightBlueB sets the background color to bright blue.
 func (builder *Builder) LightBlueB() *Builder {
 	return builder.With(LightBlueB)
 }
 
-// LightMagentaB is a syntax for LightMagentaB.
+// LightMagentaB sets the background color to bright magenta.
 func (builder *Builder) LightMagentaB() *Builder {
 	return builder.With(LightMagentaB)
 }
 
-// LightCyanB is a syntax for LightCyanB.
+// LightCyanB sets the background color to bright cyan.
 func (builder *Builder) LightCyanB() *Builder {
 	return builder.With(LightCyanB)
 }
 
-// LightWhiteB is a syntax for LightWhiteB.
+// LightWhiteB sets the background color to bright white.
 func (builder *Builder) LightWhiteB() *Builder {
 	return builder.With(LightWhiteB)
 }
 
-// Color3BitF is a syntax for Color3BitF.
+// Extended colors.
+
+// Color3BitF sets a 3-bit foreground color.
 func (builder *Builder) Color3BitF(c RGB3Bit) *Builder {
 	return builder.With(Color3BitF(c))
 }
 
-// Color3BitB is a syntax for Color3BitB.
+// Color3BitB sets a 3-bit background color.
 func (builder *Builder) Color3BitB(c RGB3Bit) *Builder {
 	return builder.With(Color3BitB(c))
 }
 
-// Color8BitF is a syntax for Color8BitF.
+// Color8BitF sets an 8-bit foreground color.
 func (builder *Builder) Color8BitF(c RGB8Bit) *Builder {
 	return builder.With(Color8BitF(c))
 }
 
-// Color8BitB is a syntax for Color8BitB.
+// Color8BitB sets an 8-bit background color.
 func (builder *Builder) Color8BitB(c RGB8Bit) *Builder {
 	return builder.With(Color8BitB(c))
 }
 
-// FullColorF is a syntax for FullColorF.
+// FullColorF sets a 24-bit foreground color.
 func (builder *Builder) FullColorF(r, g, b uint8) *Builder {
 	return builder.With(FullColorF(r, g, b))
 }
 
-// FullColorB is a syntax for FullColorB.
+// FullColorB sets a 24-bit background color.
 func (builder *Builder) FullColorB(r, g, b uint8) *Builder {
 	return builder.With(FullColorB(r, g, b))
 }
 
-// RGB3BitF is a syntax for Color3BitF with NewRGB3Bit.
+// RGB3BitF sets a 3-bit foreground color from RGB components.
 func (builder *Builder) RGB3BitF(r, g, b uint8) *Builder {
 	return builder.Color3BitF(NewRGB3Bit(r, g, b))
 }
 
-// RGB3BitB is a syntax for Color3BitB with NewRGB3Bit.
+// RGB3BitB sets a 3-bit background color from RGB components.
 func (builder *Builder) RGB3BitB(r, g, b uint8) *Builder {
 	return builder.Color3BitB(NewRGB3Bit(r, g, b))
 }
 
-// RGB8BitF is a syntax for Color8BitF with NewRGB8Bit.
+// RGB8BitF sets an 8-bit foreground color from RGB components.
 func (builder *Builder) RGB8BitF(r, g, b uint8) *Builder {
 	return builder.Color8BitF(NewRGB8Bit(r, g, b))
 }
 
-// RGB8BitB is a syntax for Color8BitB with NewRGB8Bit.
+// RGB8BitB sets an 8-bit background color from RGB components.
 func (builder *Builder) RGB8BitB(r, g, b uint8) *Builder {
 	return builder.Color8BitB(NewRGB8Bit(r, g, b))
 }

--- a/builder.go
+++ b/builder.go
@@ -6,7 +6,7 @@ type Builder struct {
 }
 
 // EmptyBuilder is an initialized Builder.
-var EmptyBuilder *Builder
+var EmptyBuilder = &Builder{empty}
 
 // NewBuilder creates a Builder from existing ANSI.
 func NewBuilder(a ...ANSI) *Builder {
@@ -381,8 +381,4 @@ func (builder *Builder) RGB8BitF(r, g, b uint8) *Builder {
 // RGB8BitB is a syntax for Color8BitB with NewRGB8Bit.
 func (builder *Builder) RGB8BitB(r, g, b uint8) *Builder {
 	return builder.Color8BitB(NewRGB8Bit(r, g, b))
-}
-
-func init() {
-	EmptyBuilder = &Builder{empty}
 }

--- a/sgr.go
+++ b/sgr.go
@@ -57,146 +57,90 @@ func FullColorB(r, g, b uint8) ANSI {
 // Style
 var (
 	// Bold set the text style to bold or increased intensity.
-	Bold ANSI
+	Bold ANSI = newSGR(1)
 
 	// Faint set the text style to faint.
-	Faint ANSI
+	Faint ANSI = newSGR(2)
 
 	// Italic set the text style to italic.
-	Italic ANSI
+	Italic ANSI = newSGR(3)
 
 	// Underline set the text style to underline.
-	Underline ANSI
+	Underline ANSI = newSGR(4)
 
 	// BlinkSlow set the text style to slow blink.
-	BlinkSlow ANSI
+	BlinkSlow ANSI = newSGR(5)
 
 	// BlinkRapid set the text style to rapid blink.
-	BlinkRapid ANSI
+	BlinkRapid ANSI = newSGR(6)
 
 	// Inverse swap the foreground color and background color.
-	Inverse ANSI
+	Inverse ANSI = newSGR(7)
 
 	// Conceal set the text style to conceal.
-	Conceal ANSI
+	Conceal ANSI = newSGR(8)
 
 	// CrossOut set the text style to crossed out.
-	CrossOut ANSI
+	CrossOut ANSI = newSGR(9)
 
 	// Frame set the text style to framed.
-	Frame ANSI
+	Frame ANSI = newSGR(51)
 
 	// Encircle set the text style to encircled.
-	Encircle ANSI
+	Encircle ANSI = newSGR(52)
 
 	// Overline set the text style to overlined.
-	Overline ANSI
+	Overline ANSI = newSGR(53)
 )
 
 // Foreground color of text.
 var (
-	// DefaultF is the default color of foreground.
-	DefaultF ANSI
+	// DefaultF is the default foreground color.
+	DefaultF ANSI = newSGR(39)
 
 	// Normal color
-	BlackF   ANSI
-	RedF     ANSI
-	GreenF   ANSI
-	YellowF  ANSI
-	BlueF    ANSI
-	MagentaF ANSI
-	CyanF    ANSI
-	WhiteF   ANSI
+	BlackF   ANSI = newSGR(30)
+	RedF     ANSI = newSGR(31)
+	GreenF   ANSI = newSGR(32)
+	YellowF  ANSI = newSGR(33)
+	BlueF    ANSI = newSGR(34)
+	MagentaF ANSI = newSGR(35)
+	CyanF    ANSI = newSGR(36)
+	WhiteF   ANSI = newSGR(37)
 
 	// Light color
-	LightBlackF   ANSI
-	LightRedF     ANSI
-	LightGreenF   ANSI
-	LightYellowF  ANSI
-	LightBlueF    ANSI
-	LightMagentaF ANSI
-	LightCyanF    ANSI
-	LightWhiteF   ANSI
+	LightBlackF   ANSI = newSGR(90)
+	LightRedF     ANSI = newSGR(91)
+	LightGreenF   ANSI = newSGR(92)
+	LightYellowF  ANSI = newSGR(93)
+	LightBlueF    ANSI = newSGR(94)
+	LightMagentaF ANSI = newSGR(95)
+	LightCyanF    ANSI = newSGR(96)
+	LightWhiteF   ANSI = newSGR(97)
 )
 
 // Background color of text.
 var (
-	// DefaultB is the default color of background.
-	DefaultB ANSI
+	// DefaultB is the default background color.
+	DefaultB ANSI = newSGR(49)
 
 	// Normal color
-	BlackB   ANSI
-	RedB     ANSI
-	GreenB   ANSI
-	YellowB  ANSI
-	BlueB    ANSI
-	MagentaB ANSI
-	CyanB    ANSI
-	WhiteB   ANSI
+	BlackB   ANSI = newSGR(40)
+	RedB     ANSI = newSGR(41)
+	GreenB   ANSI = newSGR(42)
+	YellowB  ANSI = newSGR(43)
+	BlueB    ANSI = newSGR(44)
+	MagentaB ANSI = newSGR(45)
+	CyanB    ANSI = newSGR(46)
+	WhiteB   ANSI = newSGR(47)
 
 	// Light color
-	LightBlackB   ANSI
-	LightRedB     ANSI
-	LightGreenB   ANSI
-	LightYellowB  ANSI
-	LightBlueB    ANSI
-	LightMagentaB ANSI
-	LightCyanB    ANSI
-	LightWhiteB   ANSI
+	LightBlackB   ANSI = newSGR(100)
+	LightRedB     ANSI = newSGR(101)
+	LightGreenB   ANSI = newSGR(102)
+	LightYellowB  ANSI = newSGR(103)
+	LightBlueB    ANSI = newSGR(104)
+	LightMagentaB ANSI = newSGR(105)
+	LightCyanB    ANSI = newSGR(106)
+	LightWhiteB   ANSI = newSGR(107)
 )
-
-func init() {
-	Bold = newSGR(1)
-	Faint = newSGR(2)
-	Italic = newSGR(3)
-	Underline = newSGR(4)
-	BlinkSlow = newSGR(5)
-	BlinkRapid = newSGR(6)
-	Inverse = newSGR(7)
-	Conceal = newSGR(8)
-	CrossOut = newSGR(9)
-
-	BlackF = newSGR(30)
-	RedF = newSGR(31)
-	GreenF = newSGR(32)
-	YellowF = newSGR(33)
-	BlueF = newSGR(34)
-	MagentaF = newSGR(35)
-	CyanF = newSGR(36)
-	WhiteF = newSGR(37)
-
-	DefaultF = newSGR(39)
-
-	BlackB = newSGR(40)
-	RedB = newSGR(41)
-	GreenB = newSGR(42)
-	YellowB = newSGR(43)
-	BlueB = newSGR(44)
-	MagentaB = newSGR(45)
-	CyanB = newSGR(46)
-	WhiteB = newSGR(47)
-
-	DefaultB = newSGR(49)
-
-	Frame = newSGR(51)
-	Encircle = newSGR(52)
-	Overline = newSGR(53)
-
-	LightBlackF = newSGR(90)
-	LightRedF = newSGR(91)
-	LightGreenF = newSGR(92)
-	LightYellowF = newSGR(93)
-	LightBlueF = newSGR(94)
-	LightMagentaF = newSGR(95)
-	LightCyanF = newSGR(96)
-	LightWhiteF = newSGR(97)
-
-	LightBlackB = newSGR(100)
-	LightRedB = newSGR(101)
-	LightGreenB = newSGR(102)
-	LightYellowB = newSGR(103)
-	LightBlueB = newSGR(104)
-	LightMagentaB = newSGR(105)
-	LightCyanB = newSGR(106)
-	LightWhiteB = newSGR(107)
-}

--- a/sgr.go
+++ b/sgr.go
@@ -57,41 +57,21 @@ func FullColorB(r, g, b uint8) ANSI {
 // Text styles and decorations, represented as Select Graphic Rendition (SGR)
 // parameters as defined by ECMA-48 / ISO 6429.
 var (
-	// Bold sets the text style to bold or increased intensity.
-	Bold ANSI = newSGR(1)
+	// Intensity and text presentation.
+	Bold       ANSI = newSGR(1) // enables bold or increased intensity.
+	Faint      ANSI = newSGR(2) // enables faint or decreased intensity.
+	Italic     ANSI = newSGR(3) // enables italic.
+	Underline  ANSI = newSGR(4) // enables underline.
+	BlinkSlow  ANSI = newSGR(5) // enables slow blinking.
+	BlinkRapid ANSI = newSGR(6) // enables rapid blinking.
+	Inverse    ANSI = newSGR(7) // swaps the foreground and background colors.
+	Conceal    ANSI = newSGR(8) // conceals the text.
+	CrossOut   ANSI = newSGR(9) // crosses out the text.
 
-	// Faint sets the text style to faint or decreased intensity.
-	Faint ANSI = newSGR(2)
-
-	// Italic sets the text style to italic.
-	Italic ANSI = newSGR(3)
-
-	// Underline sets the text style to underlined.
-	Underline ANSI = newSGR(4)
-
-	// BlinkSlow sets the text style to slow blinking.
-	BlinkSlow ANSI = newSGR(5)
-
-	// BlinkRapid sets the text style to rapid blinking.
-	BlinkRapid ANSI = newSGR(6)
-
-	// Inverse swaps the foreground and background colors.
-	Inverse ANSI = newSGR(7)
-
-	// Conceal sets the text style to concealed.
-	Conceal ANSI = newSGR(8)
-
-	// CrossOut sets the text style to crossed-out.
-	CrossOut ANSI = newSGR(9)
-
-	// Frame sets the text style to framed.
-	Frame ANSI = newSGR(51)
-
-	// Encircle sets the text style to encircled.
-	Encircle ANSI = newSGR(52)
-
-	// Overline sets the text style to overlined.
-	Overline ANSI = newSGR(53)
+	// Framing and overlines.
+	Frame    ANSI = newSGR(51) // enables framing.
+	Encircle ANSI = newSGR(52) // enables encircling.
+	Overline ANSI = newSGR(53) // enables overline.
 )
 
 // Foreground colors, represented as SGR parameters.
@@ -100,24 +80,24 @@ var (
 	DefaultF ANSI = newSGR(39)
 
 	// Standard foreground colors.
-	BlackF   ANSI = newSGR(30)
-	RedF     ANSI = newSGR(31)
-	GreenF   ANSI = newSGR(32)
-	YellowF  ANSI = newSGR(33)
-	BlueF    ANSI = newSGR(34)
-	MagentaF ANSI = newSGR(35)
-	CyanF    ANSI = newSGR(36)
-	WhiteF   ANSI = newSGR(37)
+	BlackF   ANSI = newSGR(30) // black.
+	RedF     ANSI = newSGR(31) // red.
+	GreenF   ANSI = newSGR(32) // green.
+	YellowF  ANSI = newSGR(33) // yellow.
+	BlueF    ANSI = newSGR(34) // blue.
+	MagentaF ANSI = newSGR(35) // magenta.
+	CyanF    ANSI = newSGR(36) // cyan.
+	WhiteF   ANSI = newSGR(37) // white (gray).
 
 	// Bright foreground colors.
-	LightBlackF   ANSI = newSGR(90)
-	LightRedF     ANSI = newSGR(91)
-	LightGreenF   ANSI = newSGR(92)
-	LightYellowF  ANSI = newSGR(93)
-	LightBlueF    ANSI = newSGR(94)
-	LightMagentaF ANSI = newSGR(95)
-	LightCyanF    ANSI = newSGR(96)
-	LightWhiteF   ANSI = newSGR(97)
+	LightBlackF   ANSI = newSGR(90) // bright black.
+	LightRedF     ANSI = newSGR(91) // bright red.
+	LightGreenF   ANSI = newSGR(92) // bright green.
+	LightYellowF  ANSI = newSGR(93) // bright yellow.
+	LightBlueF    ANSI = newSGR(94) // bright blue.
+	LightMagentaF ANSI = newSGR(95) // bright magenta.
+	LightCyanF    ANSI = newSGR(96) // bright cyan.
+	LightWhiteF   ANSI = newSGR(97) // bright white.
 )
 
 // Background colors, represented as SGR parameters.
@@ -126,22 +106,22 @@ var (
 	DefaultB ANSI = newSGR(49)
 
 	// Standard background colors.
-	BlackB   ANSI = newSGR(40)
-	RedB     ANSI = newSGR(41)
-	GreenB   ANSI = newSGR(42)
-	YellowB  ANSI = newSGR(43)
-	BlueB    ANSI = newSGR(44)
-	MagentaB ANSI = newSGR(45)
-	CyanB    ANSI = newSGR(46)
-	WhiteB   ANSI = newSGR(47)
+	BlackB   ANSI = newSGR(40) // black.
+	RedB     ANSI = newSGR(41) // red.
+	GreenB   ANSI = newSGR(42) // green.
+	YellowB  ANSI = newSGR(43) // yellow.
+	BlueB    ANSI = newSGR(44) // blue.
+	MagentaB ANSI = newSGR(45) // magenta.
+	CyanB    ANSI = newSGR(46) // cyan.
+	WhiteB   ANSI = newSGR(47) // white (gray).
 
 	// Bright background colors.
-	LightBlackB   ANSI = newSGR(100)
-	LightRedB     ANSI = newSGR(101)
-	LightGreenB   ANSI = newSGR(102)
-	LightYellowB  ANSI = newSGR(103)
-	LightBlueB    ANSI = newSGR(104)
-	LightMagentaB ANSI = newSGR(105)
-	LightCyanB    ANSI = newSGR(106)
-	LightWhiteB   ANSI = newSGR(107)
+	LightBlackB   ANSI = newSGR(100) // bright black.
+	LightRedB     ANSI = newSGR(101) // bright red.
+	LightGreenB   ANSI = newSGR(102) // bright green.
+	LightYellowB  ANSI = newSGR(103) // bright yellow.
+	LightBlueB    ANSI = newSGR(104) // bright blue.
+	LightMagentaB ANSI = newSGR(105) // bright magenta.
+	LightCyanB    ANSI = newSGR(106) // bright cyan.
+	LightWhiteB   ANSI = newSGR(107) // bright white.
 )

--- a/sgr.go
+++ b/sgr.go
@@ -4,101 +4,102 @@ import (
 	"fmt"
 )
 
-// RGB3Bit is a 3bit RGB color.
+// RGB3Bit is a 3-bit RGB color.
 type RGB3Bit uint8
 
-// RGB8Bit is a 8bit RGB color.
+// RGB8Bit is an 8-bit indexed color.
 type RGB8Bit uint8
 
 func newSGR(n uint) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dm", n))
 }
 
-// NewRGB3Bit create a RGB3Bit from given RGB.
+// NewRGB3Bit returns a 3-bit color from the given RGB values.
 func NewRGB3Bit(r, g, b uint8) RGB3Bit {
 	return RGB3Bit((r >> 7) | ((g >> 6) & 0x2) | ((b >> 5) & 0x4))
 }
 
-// NewRGB8Bit create a RGB8Bit from given RGB.
+// NewRGB8Bit returns an 8-bit indexed color from the given RGB values.
 func NewRGB8Bit(r, g, b uint8) RGB8Bit {
 	return RGB8Bit(16 + 36*(r/43) + 6*(g/43) + b/43)
 }
 
-// Color3BitF set the foreground color of text.
+// Color3BitF returns an SGR sequence that sets the foreground color.
 func Color3BitF(c RGB3Bit) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dm", c+30))
 }
 
-// Color3BitB set the background color of text.
+// Color3BitB returns an SGR sequence that sets the background color.
 func Color3BitB(c RGB3Bit) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dm", c+40))
 }
 
-// Color8BitF set the foreground color of text.
+// Color8BitF returns an SGR sequence that sets the 8-bit foreground color.
 func Color8BitF(c RGB8Bit) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"38;5;%dm", c))
 }
 
-// Color8BitB set the background color of text.
+// Color8BitB returns an SGR sequence that sets the 8-bit background color.
 func Color8BitB(c RGB8Bit) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"48;5;%dm", c))
 }
 
-// FullColorF set the foreground color of text.
+// FullColorF returns an SGR sequence that sets the 24-bit foreground color.
 func FullColorF(r, g, b uint8) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"38;2;%d;%d;%dm", r, g, b))
 }
 
-// FullColorB set the foreground color of text.
+// FullColorB returns an SGR sequence that sets the 24-bit background color.
 func FullColorB(r, g, b uint8) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"48;2;%d;%d;%dm", r, g, b))
 }
 
-// Style
+// Text styles and decorations, represented as Select Graphic Rendition (SGR)
+// parameters as defined by ECMA-48 / ISO 6429.
 var (
-	// Bold set the text style to bold or increased intensity.
+	// Bold sets the text style to bold or increased intensity.
 	Bold ANSI = newSGR(1)
 
-	// Faint set the text style to faint.
+	// Faint sets the text style to faint or decreased intensity.
 	Faint ANSI = newSGR(2)
 
-	// Italic set the text style to italic.
+	// Italic sets the text style to italic.
 	Italic ANSI = newSGR(3)
 
-	// Underline set the text style to underline.
+	// Underline sets the text style to underlined.
 	Underline ANSI = newSGR(4)
 
-	// BlinkSlow set the text style to slow blink.
+	// BlinkSlow sets the text style to slow blinking.
 	BlinkSlow ANSI = newSGR(5)
 
-	// BlinkRapid set the text style to rapid blink.
+	// BlinkRapid sets the text style to rapid blinking.
 	BlinkRapid ANSI = newSGR(6)
 
-	// Inverse swap the foreground color and background color.
+	// Inverse swaps the foreground and background colors.
 	Inverse ANSI = newSGR(7)
 
-	// Conceal set the text style to conceal.
+	// Conceal sets the text style to concealed.
 	Conceal ANSI = newSGR(8)
 
-	// CrossOut set the text style to crossed out.
+	// CrossOut sets the text style to crossed-out.
 	CrossOut ANSI = newSGR(9)
 
-	// Frame set the text style to framed.
+	// Frame sets the text style to framed.
 	Frame ANSI = newSGR(51)
 
-	// Encircle set the text style to encircled.
+	// Encircle sets the text style to encircled.
 	Encircle ANSI = newSGR(52)
 
-	// Overline set the text style to overlined.
+	// Overline sets the text style to overlined.
 	Overline ANSI = newSGR(53)
 )
 
-// Foreground color of text.
+// Foreground colors, represented as SGR parameters.
 var (
-	// DefaultF is the default foreground color.
+	// DefaultF restores the default foreground color.
 	DefaultF ANSI = newSGR(39)
 
-	// Normal color
+	// Standard foreground colors.
 	BlackF   ANSI = newSGR(30)
 	RedF     ANSI = newSGR(31)
 	GreenF   ANSI = newSGR(32)
@@ -108,7 +109,7 @@ var (
 	CyanF    ANSI = newSGR(36)
 	WhiteF   ANSI = newSGR(37)
 
-	// Light color
+	// Bright foreground colors.
 	LightBlackF   ANSI = newSGR(90)
 	LightRedF     ANSI = newSGR(91)
 	LightGreenF   ANSI = newSGR(92)
@@ -119,12 +120,12 @@ var (
 	LightWhiteF   ANSI = newSGR(97)
 )
 
-// Background color of text.
+// Background colors, represented as SGR parameters.
 var (
-	// DefaultB is the default background color.
+	// DefaultB restores the default background color.
 	DefaultB ANSI = newSGR(49)
 
-	// Normal color
+	// Standard background colors.
 	BlackB   ANSI = newSGR(40)
 	RedB     ANSI = newSGR(41)
 	GreenB   ANSI = newSGR(42)
@@ -134,7 +135,7 @@ var (
 	CyanB    ANSI = newSGR(46)
 	WhiteB   ANSI = newSGR(47)
 
-	// Light color
+	// Bright background colors.
 	LightBlackB   ANSI = newSGR(100)
 	LightRedB     ANSI = newSGR(101)
 	LightGreenB   ANSI = newSGR(102)

--- a/sgr.go
+++ b/sgr.go
@@ -11,7 +11,7 @@ type RGB3Bit uint8
 type RGB8Bit uint8
 
 func newSGR(n uint) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"%dm", n))
+	return newAnsi(fmt.Sprintf(Esc+"%dm", n))
 }
 
 // NewRGB3Bit returns a 3-bit color from the given RGB values.
@@ -26,32 +26,32 @@ func NewRGB8Bit(r, g, b uint8) RGB8Bit {
 
 // Color3BitF returns an SGR sequence that sets the foreground color.
 func Color3BitF(c RGB3Bit) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"%dm", c+30))
+	return newAnsi(fmt.Sprintf(Esc+"%dm", c+30))
 }
 
 // Color3BitB returns an SGR sequence that sets the background color.
 func Color3BitB(c RGB3Bit) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"%dm", c+40))
+	return newAnsi(fmt.Sprintf(Esc+"%dm", c+40))
 }
 
 // Color8BitF returns an SGR sequence that sets the 8-bit foreground color.
 func Color8BitF(c RGB8Bit) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"38;5;%dm", c))
+	return newAnsi(fmt.Sprintf(Esc+"38;5;%dm", c))
 }
 
 // Color8BitB returns an SGR sequence that sets the 8-bit background color.
 func Color8BitB(c RGB8Bit) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"48;5;%dm", c))
+	return newAnsi(fmt.Sprintf(Esc+"48;5;%dm", c))
 }
 
 // FullColorF returns an SGR sequence that sets the 24-bit foreground color.
 func FullColorF(r, g, b uint8) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"38;2;%d;%d;%dm", r, g, b))
+	return newAnsi(fmt.Sprintf(Esc+"38;2;%d;%d;%dm", r, g, b))
 }
 
 // FullColorB returns an SGR sequence that sets the 24-bit background color.
 func FullColorB(r, g, b uint8) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"48;2;%d;%d;%dm", r, g, b))
+	return newAnsi(fmt.Sprintf(Esc+"48;2;%d;%d;%dm", r, g, b))
 }
 
 // Text styles and decorations, represented as Select Graphic Rendition (SGR)


### PR DESCRIPTION
### remove redundant init functions

Remove the init functions and instead set the variables directly.

### touch-up godoc

- touch-up Builder godoc
- godoc: document per line
- godoc: tighten-up cursor control godoc

### export "esc" const

This is mostly for documentation purposes; exporting the type allows
the godoc to become visible.

### define const for erase-modes

The current implementation considers erase-modes for "lines"
and "display" to be equivalent; while there's an overlap,
they have distinct values.

This patch:

- Introduces type-aliases for each to make the lists self-describing.
  Aliases are used to remain backward-compatible.
- Changes the EraseDisplay and EraseLine functions to use the
  corresponding type-alias.

The EraseModes struct is left in place, although it's currently
not used in the codebase itself; it's worth considering to mark
it deprecated (and recommend users to use the defined consts).

