### PR TITLE
add Benchmark tests and use strconv instead of fmt.Sprintf for ANSI construction

### DIFF
--- a/aec.go
+++ b/aec.go
@@ -42,7 +42,7 @@ var (
 	Report ANSI = newAnsi(esc + "6n")
 )
 
-// Up moves up the cursor.
+// Up moves the cursor up by n positions (CUU).
 func Up(n uint) ANSI {
 	if n == 0 {
 		return empty
@@ -50,7 +50,7 @@ func Up(n uint) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dA", n))
 }
 
-// Down moves down the cursor.
+// Down moves the cursor down by n positions (CUD).
 func Down(n uint) ANSI {
 	if n == 0 {
 		return empty
@@ -58,7 +58,7 @@ func Down(n uint) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dB", n))
 }
 
-// Right moves right the cursor.
+// Right moves the cursor right by n positions (CUF).
 func Right(n uint) ANSI {
 	if n == 0 {
 		return empty
@@ -66,7 +66,7 @@ func Right(n uint) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dC", n))
 }
 
-// Left moves left the cursor.
+// Left moves the cursor left by n positions (CUB).
 func Left(n uint) ANSI {
 	if n == 0 {
 		return empty
@@ -74,7 +74,7 @@ func Left(n uint) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dD", n))
 }
 
-// NextLine moves down the cursor to head of a line.
+// NextLine moves the cursor down n lines and to the beginning of the line (CNL).
 func NextLine(n uint) ANSI {
 	if n == 0 {
 		return empty
@@ -82,7 +82,7 @@ func NextLine(n uint) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dE", n))
 }
 
-// PreviousLine moves up the cursor to head of a line.
+// PreviousLine moves the cursor up n lines and to the beginning of the line (CPL).
 func PreviousLine(n uint) ANSI {
 	if n == 0 {
 		return empty
@@ -90,27 +90,27 @@ func PreviousLine(n uint) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dF", n))
 }
 
-// Column set the cursor position to a given column.
+// Column sets the cursor position to a given column (CHA).
 func Column(col uint) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dG", col))
 }
 
-// Position set the cursor position to a given absolute position.
+// Position sets the cursor position to a given absolute position (CUP).
 func Position(row, col uint) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%d;%dH", row, col))
 }
 
-// EraseDisplay erases display by given EraseMode.
+// EraseDisplay erases the display using the given EraseMode (ED).
 func EraseDisplay(m EraseMode) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dJ", m))
 }
 
-// EraseLine erases lines by given EraseMode.
+// EraseLine erases the line using the given EraseMode (EL).
 func EraseLine(m EraseMode) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dK", m))
 }
 
-// ScrollUp scrolls up the page.
+// ScrollUp scrolls the display up by n lines (SU).
 func ScrollUp(n int) ANSI {
 	if n == 0 {
 		return empty
@@ -118,7 +118,7 @@ func ScrollUp(n int) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"%dS", n))
 }
 
-// ScrollDown scrolls down the page.
+// ScrollDown scrolls the display down by n lines (SD).
 func ScrollDown(n int) ANSI {
 	if n == 0 {
 		return empty

--- a/aec.go
+++ b/aec.go
@@ -1,6 +1,6 @@
 package aec
 
-import "fmt"
+import "strconv"
 
 // EraseMode is listed in a variable EraseModes.
 type EraseMode uint
@@ -43,85 +43,116 @@ var (
 )
 
 // Up moves the cursor up by n positions (CUU).
-func Up(n uint) ANSI {
-	if n == 0 {
-		return empty
-	}
-	return newAnsi(fmt.Sprintf(esc+"%dA", n))
-}
+func Up(n uint) ANSI { return csiUintDefault1(n, 'A') }
 
 // Down moves the cursor down by n positions (CUD).
-func Down(n uint) ANSI {
-	if n == 0 {
-		return empty
-	}
-	return newAnsi(fmt.Sprintf(esc+"%dB", n))
-}
+func Down(n uint) ANSI { return csiUintDefault1(n, 'B') }
 
 // Right moves the cursor right by n positions (CUF).
-func Right(n uint) ANSI {
-	if n == 0 {
-		return empty
-	}
-	return newAnsi(fmt.Sprintf(esc+"%dC", n))
-}
+func Right(n uint) ANSI { return csiUintDefault1(n, 'C') }
 
 // Left moves the cursor left by n positions (CUB).
-func Left(n uint) ANSI {
-	if n == 0 {
-		return empty
-	}
-	return newAnsi(fmt.Sprintf(esc+"%dD", n))
-}
+func Left(n uint) ANSI { return csiUintDefault1(n, 'D') }
 
 // NextLine moves the cursor down n lines and to the beginning of the line (CNL).
-func NextLine(n uint) ANSI {
-	if n == 0 {
-		return empty
-	}
-	return newAnsi(fmt.Sprintf(esc+"%dE", n))
-}
+func NextLine(n uint) ANSI { return csiUintDefault1(n, 'E') }
 
 // PreviousLine moves the cursor up n lines and to the beginning of the line (CPL).
-func PreviousLine(n uint) ANSI {
-	if n == 0 {
-		return empty
-	}
-	return newAnsi(fmt.Sprintf(esc+"%dF", n))
-}
+func PreviousLine(n uint) ANSI { return csiUintDefault1(n, 'F') }
 
 // Column sets the cursor position to a given column (CHA).
 func Column(col uint) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"%dG", col))
+	if col <= 1 {
+		return newAnsi(esc + "G")
+	}
+	return csiUint(col, 'G')
 }
 
 // Position sets the cursor position to a given absolute position (CUP).
 func Position(row, col uint) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"%d;%dH", row, col))
+	// According to ECMA-48 (ISO/IEC 6429), cursor positioning (CUP) uses 1-based
+	// coordinates with default values of 1;1. Empty or zero parameters are treated
+	// as defaults, so 0;0 is effectively interpreted as 1;1 (home position).
+	if row == 0 {
+		row = 1
+	}
+	if col == 0 {
+		col = 1
+	}
+	if row == 1 && col == 1 {
+		// ESC[0;0H == ESC[1;1H == ESC[H
+		return newAnsi(esc + "H")
+	}
+	buf := make([]byte, 0, len(esc)+42)
+	buf = append(buf, esc...)
+	buf = strconv.AppendUint(buf, uint64(row), 10)
+	buf = append(buf, ';')
+	buf = strconv.AppendUint(buf, uint64(col), 10)
+	buf = append(buf, 'H')
+	return newAnsi(string(buf))
 }
 
 // EraseDisplay erases the display using the given EraseMode (ED).
 func EraseDisplay(m EraseMode) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"%dJ", m))
+	if m == 0 {
+		return newAnsi(esc + "J")
+	}
+	return csiUint(uint(m), 'J')
 }
 
 // EraseLine erases the line using the given EraseMode (EL).
 func EraseLine(m EraseMode) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"%dK", m))
+	if m == 0 {
+		return newAnsi(esc + "K")
+	}
+	return csiUint(uint(m), 'K')
 }
 
-// ScrollUp scrolls the display up by n lines (SU).
+// ScrollUp scrolls the display up by n lines (SU). n <= 0 is a no-op.
 func ScrollUp(n int) ANSI {
-	if n == 0 {
-		return empty
-	}
-	return newAnsi(fmt.Sprintf(esc+"%dS", n))
+	return scroll(n, 'S')
 }
 
-// ScrollDown scrolls the display down by n lines (SD).
+// ScrollDown scrolls the display down by n lines (SD). n <= 0 is a no-op.
 func ScrollDown(n int) ANSI {
-	if n == 0 {
+	return scroll(n, 'T')
+}
+
+func scroll(n int, direction byte) ANSI {
+	switch {
+	case n <= 0:
+		// Negative counts are not defined for SU/SD; treat them as a no-op.
 		return empty
+	case n == 1:
+		return newAnsi(esc + string(direction))
+	default:
+		return csiInt(n, direction)
 	}
-	return newAnsi(fmt.Sprintf(esc+"%dT", n))
+}
+
+func csiInt(n int, suffix byte) ANSI {
+	buf := make([]byte, 0, len(esc)+21)
+	buf = append(buf, esc...)
+	buf = strconv.AppendInt(buf, int64(n), 10)
+	buf = append(buf, suffix)
+	return newAnsi(string(buf))
+}
+
+func csiUintDefault1(n uint, direction byte) ANSI {
+	switch n {
+	case 0:
+		return empty
+	case 1:
+		return newAnsi(esc + string(direction))
+	default:
+		return csiUint(n, direction)
+	}
+}
+
+func csiUint(n uint, suffix byte) ANSI {
+	buf := make([]byte, 0, len(esc)+21)
+	buf = append(buf, esc...)
+	buf = strconv.AppendUint(buf, uint64(n), 10)
+	buf = append(buf, suffix)
+	return newAnsi(string(buf))
 }

--- a/aec.go
+++ b/aec.go
@@ -7,7 +7,7 @@ type EraseMode uint
 
 var (
 	// EraseModes is a list of EraseMode.
-	EraseModes struct {
+	EraseModes = struct {
 		// All erase all.
 		All EraseMode
 
@@ -16,22 +16,30 @@ var (
 
 		// Tail erase to tail.
 		Tail EraseMode
+	}{
+		Tail: 0,
+		Head: 1,
+		All:  2,
 	}
 
-	// Save saves the cursor position.
-	Save ANSI
+	// Save saves the cursor position. It uses both SCO ("ESC[s") and DEC
+	// ("ESC7") sequences as those were never standardized as part of the
+	// ANSI.
+	Save ANSI = newAnsi(esc + "s" + "\x1b7")
 
-	// Restore restores the cursor position.
-	Restore ANSI
+	// Restore restores the cursor position. It uses both SCO ("ESC[u") and
+	// DEC ("ESC8") sequences as those were never standardized as part of
+	// the ANSI.
+	Restore ANSI = newAnsi(esc + "u" + "\x1b8")
 
 	// Hide hides the cursor.
-	Hide ANSI
+	Hide ANSI = newAnsi(esc + "?25l")
 
 	// Show shows the cursor.
-	Show ANSI
+	Show ANSI = newAnsi(esc + "?25h")
 
 	// Report reports the cursor position.
-	Report ANSI
+	Report ANSI = newAnsi(esc + "6n")
 )
 
 // Up moves up the cursor.
@@ -116,24 +124,4 @@ func ScrollDown(n int) ANSI {
 		return empty
 	}
 	return newAnsi(fmt.Sprintf(esc+"%dT", n))
-}
-
-func init() {
-	EraseModes = struct {
-		All  EraseMode
-		Head EraseMode
-		Tail EraseMode
-	}{
-		Tail: 0,
-		Head: 1,
-		All:  2,
-	}
-
-	// Save use both SCO (ESC[s) and DEC (ESC7) sequences as those were never standardised as part of the ANSI
-	Save = newAnsi(esc + "s" + "\x1b7")
-	// Restore use both SCO (ESC[u) and DEC (ESC8) and DEC sequences as those were never standardised as part of the ANSI
-	Restore = newAnsi(esc + "u" + "\x1b8")
-	Hide = newAnsi(esc + "?25l")
-	Show = newAnsi(esc + "?25h")
-	Report = newAnsi(esc + "6n")
 }

--- a/aec_test.go
+++ b/aec_test.go
@@ -1,0 +1,71 @@
+package aec_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/morikuni/aec"
+)
+
+var benchValues = []struct {
+	n uint
+}{
+	{n: 0},   // 0,1 special case
+	{n: 2},   // 1 digit
+	{n: 20},  // 2 digit
+	{n: 200}, // 3 digits
+}
+
+// Representative benchmark for all single-parameter uint CSI generators:
+// Up, Down, Left, Right, NextLine, PreviousLine, Column, EraseDisplay, and EraseLine.
+func BenchmarkCursor(b *testing.B) {
+	for _, tc := range benchValues {
+		b.Run(fmt.Sprintf("%d", tc.n), func(b *testing.B) {
+			var a aec.ANSI
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				a = aec.Up(tc.n)
+			}
+			sinkANSI = a
+		})
+	}
+}
+
+// Covers the two-parameter uint CSI path used by [aec.Position].
+func BenchmarkPosition(b *testing.B) {
+	var tests = []struct {
+		row uint
+		col uint
+	}{
+		{row: 0, col: 0},     // 0,1 special case
+		{row: 2, col: 2},     // 1 digit
+		{row: 20, col: 20},   // 2 digit
+		{row: 200, col: 200}, // 3 digits
+		{row: 5, col: 15},
+	}
+	for _, tc := range tests {
+		b.Run(fmt.Sprintf("%d,%d", tc.row, tc.col), func(b *testing.B) {
+			var a aec.ANSI
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				a = aec.Position(tc.row, tc.col)
+			}
+			sinkANSI = a
+		})
+	}
+}
+
+// Representative benchmark for all single-parameter int CSI
+// generators ([aec.ScrollUp], [aec.ScrollDown]).
+func BenchmarkScrollUpDown(b *testing.B) {
+	for _, tc := range benchValues {
+		b.Run(fmt.Sprintf("%d", tc.n), func(b *testing.B) {
+			var a aec.ANSI
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				a = aec.ScrollUp(int(tc.n))
+			}
+			sinkANSI = a
+		})
+	}
+}

--- a/ansi.go
+++ b/ansi.go
@@ -8,7 +8,7 @@ import (
 const esc = "\x1b["
 
 // Reset resets SGR effect.
-const Reset string = "\x1b[0m"
+const Reset = "\x1b[0m"
 
 var empty = newAnsi("")
 
@@ -23,6 +23,7 @@ type ANSI interface {
 	Apply(string) string
 }
 
+// ansiImpl represents an ANSI escape code.
 type ansiImpl string
 
 func newAnsi(s string) *ansiImpl {
@@ -30,19 +31,22 @@ func newAnsi(s string) *ansiImpl {
 	return &r
 }
 
+// With returns a new ANSICode sequence composed of this and the provided ANSI codes.
 func (a *ansiImpl) With(ansi ...ANSI) ANSI {
 	return concat(append([]ANSI{a}, ansi...))
 }
 
+// Apply wraps the given string with the ANSI sequence and a reset code.
 func (a *ansiImpl) Apply(s string) string {
 	return a.String() + s + Reset
 }
 
+// String returns the ANSICode escape code as a string.
 func (a *ansiImpl) String() string {
 	return string(*a)
 }
 
-// Apply wraps given string in ANSIs.
+// Apply wraps the given string with all provided ANSI sequences.
 func Apply(s string, ansi ...ANSI) string {
 	if len(ansi) == 0 {
 		return s
@@ -50,6 +54,7 @@ func Apply(s string, ansi ...ANSI) string {
 	return concat(ansi).Apply(s)
 }
 
+// concat combines multiple ANSI codes into a single ANSI sequence.
 func concat(ansi []ANSI) ANSI {
 	strs := make([]string, 0, len(ansi))
 	for _, p := range ansi {

--- a/builder.go
+++ b/builder.go
@@ -6,7 +6,7 @@ type Builder struct {
 }
 
 // EmptyBuilder is an initialized Builder.
-var EmptyBuilder *Builder
+var EmptyBuilder = &Builder{empty}
 
 // NewBuilder creates a Builder from existing ANSI.
 func NewBuilder(a ...ANSI) *Builder {
@@ -381,8 +381,4 @@ func (builder *Builder) RGB8BitF(r, g, b uint8) *Builder {
 // RGB8BitB is a syntax for Color8BitB with NewRGB8Bit.
 func (builder *Builder) RGB8BitB(r, g, b uint8) *Builder {
 	return builder.Color8BitB(NewRGB8Bit(r, g, b))
-}
-
-func init() {
-	EmptyBuilder = &Builder{empty}
 }

--- a/sgr.go
+++ b/sgr.go
@@ -57,146 +57,90 @@ func FullColorB(r, g, b uint8) ANSI {
 // Style
 var (
 	// Bold set the text style to bold or increased intensity.
-	Bold ANSI
+	Bold ANSI = newSGR(1)
 
 	// Faint set the text style to faint.
-	Faint ANSI
+	Faint ANSI = newSGR(2)
 
 	// Italic set the text style to italic.
-	Italic ANSI
+	Italic ANSI = newSGR(3)
 
 	// Underline set the text style to underline.
-	Underline ANSI
+	Underline ANSI = newSGR(4)
 
 	// BlinkSlow set the text style to slow blink.
-	BlinkSlow ANSI
+	BlinkSlow ANSI = newSGR(5)
 
 	// BlinkRapid set the text style to rapid blink.
-	BlinkRapid ANSI
+	BlinkRapid ANSI = newSGR(6)
 
 	// Inverse swap the foreground color and background color.
-	Inverse ANSI
+	Inverse ANSI = newSGR(7)
 
 	// Conceal set the text style to conceal.
-	Conceal ANSI
+	Conceal ANSI = newSGR(8)
 
 	// CrossOut set the text style to crossed out.
-	CrossOut ANSI
+	CrossOut ANSI = newSGR(9)
 
 	// Frame set the text style to framed.
-	Frame ANSI
+	Frame ANSI = newSGR(51)
 
 	// Encircle set the text style to encircled.
-	Encircle ANSI
+	Encircle ANSI = newSGR(52)
 
 	// Overline set the text style to overlined.
-	Overline ANSI
+	Overline ANSI = newSGR(53)
 )
 
 // Foreground color of text.
 var (
-	// DefaultF is the default color of foreground.
-	DefaultF ANSI
+	// DefaultF is the default foreground color.
+	DefaultF ANSI = newSGR(39)
 
 	// Normal color
-	BlackF   ANSI
-	RedF     ANSI
-	GreenF   ANSI
-	YellowF  ANSI
-	BlueF    ANSI
-	MagentaF ANSI
-	CyanF    ANSI
-	WhiteF   ANSI
+	BlackF   ANSI = newSGR(30)
+	RedF     ANSI = newSGR(31)
+	GreenF   ANSI = newSGR(32)
+	YellowF  ANSI = newSGR(33)
+	BlueF    ANSI = newSGR(34)
+	MagentaF ANSI = newSGR(35)
+	CyanF    ANSI = newSGR(36)
+	WhiteF   ANSI = newSGR(37)
 
 	// Light color
-	LightBlackF   ANSI
-	LightRedF     ANSI
-	LightGreenF   ANSI
-	LightYellowF  ANSI
-	LightBlueF    ANSI
-	LightMagentaF ANSI
-	LightCyanF    ANSI
-	LightWhiteF   ANSI
+	LightBlackF   ANSI = newSGR(90)
+	LightRedF     ANSI = newSGR(91)
+	LightGreenF   ANSI = newSGR(92)
+	LightYellowF  ANSI = newSGR(93)
+	LightBlueF    ANSI = newSGR(94)
+	LightMagentaF ANSI = newSGR(95)
+	LightCyanF    ANSI = newSGR(96)
+	LightWhiteF   ANSI = newSGR(97)
 )
 
 // Background color of text.
 var (
-	// DefaultB is the default color of background.
-	DefaultB ANSI
+	// DefaultB is the default background color.
+	DefaultB ANSI = newSGR(49)
 
 	// Normal color
-	BlackB   ANSI
-	RedB     ANSI
-	GreenB   ANSI
-	YellowB  ANSI
-	BlueB    ANSI
-	MagentaB ANSI
-	CyanB    ANSI
-	WhiteB   ANSI
+	BlackB   ANSI = newSGR(40)
+	RedB     ANSI = newSGR(41)
+	GreenB   ANSI = newSGR(42)
+	YellowB  ANSI = newSGR(43)
+	BlueB    ANSI = newSGR(44)
+	MagentaB ANSI = newSGR(45)
+	CyanB    ANSI = newSGR(46)
+	WhiteB   ANSI = newSGR(47)
 
 	// Light color
-	LightBlackB   ANSI
-	LightRedB     ANSI
-	LightGreenB   ANSI
-	LightYellowB  ANSI
-	LightBlueB    ANSI
-	LightMagentaB ANSI
-	LightCyanB    ANSI
-	LightWhiteB   ANSI
+	LightBlackB   ANSI = newSGR(100)
+	LightRedB     ANSI = newSGR(101)
+	LightGreenB   ANSI = newSGR(102)
+	LightYellowB  ANSI = newSGR(103)
+	LightBlueB    ANSI = newSGR(104)
+	LightMagentaB ANSI = newSGR(105)
+	LightCyanB    ANSI = newSGR(106)
+	LightWhiteB   ANSI = newSGR(107)
 )
-
-func init() {
-	Bold = newSGR(1)
-	Faint = newSGR(2)
-	Italic = newSGR(3)
-	Underline = newSGR(4)
-	BlinkSlow = newSGR(5)
-	BlinkRapid = newSGR(6)
-	Inverse = newSGR(7)
-	Conceal = newSGR(8)
-	CrossOut = newSGR(9)
-
-	BlackF = newSGR(30)
-	RedF = newSGR(31)
-	GreenF = newSGR(32)
-	YellowF = newSGR(33)
-	BlueF = newSGR(34)
-	MagentaF = newSGR(35)
-	CyanF = newSGR(36)
-	WhiteF = newSGR(37)
-
-	DefaultF = newSGR(39)
-
-	BlackB = newSGR(40)
-	RedB = newSGR(41)
-	GreenB = newSGR(42)
-	YellowB = newSGR(43)
-	BlueB = newSGR(44)
-	MagentaB = newSGR(45)
-	CyanB = newSGR(46)
-	WhiteB = newSGR(47)
-
-	DefaultB = newSGR(49)
-
-	Frame = newSGR(51)
-	Encircle = newSGR(52)
-	Overline = newSGR(53)
-
-	LightBlackF = newSGR(90)
-	LightRedF = newSGR(91)
-	LightGreenF = newSGR(92)
-	LightYellowF = newSGR(93)
-	LightBlueF = newSGR(94)
-	LightMagentaF = newSGR(95)
-	LightCyanF = newSGR(96)
-	LightWhiteF = newSGR(97)
-
-	LightBlackB = newSGR(100)
-	LightRedB = newSGR(101)
-	LightGreenB = newSGR(102)
-	LightYellowB = newSGR(103)
-	LightBlueB = newSGR(104)
-	LightMagentaB = newSGR(105)
-	LightCyanB = newSGR(106)
-	LightWhiteB = newSGR(107)
-}

--- a/sgr.go
+++ b/sgr.go
@@ -1,8 +1,6 @@
 package aec
 
-import (
-	"fmt"
-)
+import "strconv"
 
 // RGB3Bit is a 3bit RGB color.
 type RGB3Bit uint8
@@ -10,8 +8,30 @@ type RGB3Bit uint8
 // RGB8Bit is a 8bit RGB color.
 type RGB8Bit uint8
 
-func newSGR(n uint) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"%dm", n))
+func newSGR(n uint8) ANSI {
+	return sgr1("", n)
+}
+
+func sgr1(prefix string, n uint8) ANSI {
+	buf := make([]byte, 0, len(esc)+len(prefix)+3+1)
+	buf = append(buf, esc...)
+	buf = append(buf, prefix...)
+	buf = strconv.AppendUint(buf, uint64(n), 10)
+	buf = append(buf, 'm')
+	return newAnsi(string(buf))
+}
+
+func newFullColor(prefix string, a, b, c uint8) ANSI {
+	buf := make([]byte, 0, len(esc)+len(prefix)+3+1+3+1+3+1)
+	buf = append(buf, esc...)
+	buf = append(buf, prefix...)
+	buf = strconv.AppendUint(buf, uint64(a), 10)
+	buf = append(buf, ';')
+	buf = strconv.AppendUint(buf, uint64(b), 10)
+	buf = append(buf, ';')
+	buf = strconv.AppendUint(buf, uint64(c), 10)
+	buf = append(buf, 'm')
+	return newAnsi(string(buf))
 }
 
 // NewRGB3Bit create a RGB3Bit from given RGB.
@@ -26,32 +46,32 @@ func NewRGB8Bit(r, g, b uint8) RGB8Bit {
 
 // Color3BitF set the foreground color of text.
 func Color3BitF(c RGB3Bit) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"%dm", c+30))
+	return newSGR(uint8(c + 30))
 }
 
 // Color3BitB set the background color of text.
 func Color3BitB(c RGB3Bit) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"%dm", c+40))
+	return newSGR(uint8(c + 40))
 }
 
 // Color8BitF set the foreground color of text.
 func Color8BitF(c RGB8Bit) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"38;5;%dm", c))
+	return sgr1("38;5;", uint8(c))
 }
 
 // Color8BitB set the background color of text.
 func Color8BitB(c RGB8Bit) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"48;5;%dm", c))
+	return sgr1("48;5;", uint8(c))
 }
 
 // FullColorF set the foreground color of text.
 func FullColorF(r, g, b uint8) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"38;2;%d;%d;%dm", r, g, b))
+	return newFullColor("38;2;", r, g, b)
 }
 
 // FullColorB set the background color of text.
 func FullColorB(r, g, b uint8) ANSI {
-	return newAnsi(fmt.Sprintf(esc+"48;2;%d;%d;%dm", r, g, b))
+	return newFullColor("48;2;", r, g, b)
 }
 
 // Style

--- a/sgr.go
+++ b/sgr.go
@@ -49,7 +49,7 @@ func FullColorF(r, g, b uint8) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"38;2;%d;%d;%dm", r, g, b))
 }
 
-// FullColorB set the foreground color of text.
+// FullColorB set the background color of text.
 func FullColorB(r, g, b uint8) ANSI {
 	return newAnsi(fmt.Sprintf(esc+"48;2;%d;%d;%dm", r, g, b))
 }

--- a/sgr_test.go
+++ b/sgr_test.go
@@ -1,0 +1,39 @@
+package aec_test
+
+import (
+	"testing"
+
+	"github.com/morikuni/aec"
+)
+
+var sinkANSI aec.ANSI // used in benchmarks to avoid compiler optimizations
+
+func BenchmarkColor3BitF(b *testing.B) {
+	b.ReportAllocs()
+
+	var a aec.ANSI
+	for i := 0; i < b.N; i++ {
+		a = aec.Color3BitF(3)
+	}
+	sinkANSI = a
+}
+
+func BenchmarkColor8BitF(b *testing.B) {
+	b.ReportAllocs()
+
+	var a aec.ANSI
+	for i := 0; i < b.N; i++ {
+		a = aec.Color8BitF(128)
+	}
+	sinkANSI = a
+}
+
+func BenchmarkFullColorF(b *testing.B) {
+	b.ReportAllocs()
+
+	var a aec.ANSI
+	for i := 0; i < b.N; i++ {
+		a = aec.FullColorF(255, 128, 0)
+	}
+	sinkANSI = a
+}


### PR DESCRIPTION
- [ ] depends on / stacked on https://github.com/morikuni/aec/pull/8

------

### add benchmark tests

```
goos: darwin
goarch: arm64
pkg: github.com/morikuni/aec
cpu: Apple M3 Pro

BenchmarkCursor/0            940589062     1.072 ns/op    0 B/op    0 allocs/op
BenchmarkCursor/2             21112914    64.86 ns/op    20 B/op    2 allocs/op
BenchmarkCursor/20            18367920    70.76 ns/op    21 B/op    2 allocs/op
BenchmarkCursor/200           17084241    70.71 ns/op    24 B/op    2 allocs/op

BenchmarkPosition/0,0         13334660    91.47 ns/op    24 B/op    2 allocs/op
BenchmarkPosition/2,2         13352409    94.05 ns/op    24 B/op    2 allocs/op
BenchmarkPosition/20,20       12992484    94.37 ns/op    24 B/op    2 allocs/op
BenchmarkPosition/200,200     12199471   100.20 ns/op    32 B/op    2 allocs/op
BenchmarkPosition/5,15        12582919    96.98 ns/op    24 B/op    2 allocs/op

BenchmarkScrollUpDown/0      645249318     1.61 ns/op     0 B/op    0 allocs/op
BenchmarkScrollUpDown/2       17620928    69.66 ns/op    20 B/op    2 allocs/op
BenchmarkScrollUpDown/20      17966480    69.91 ns/op    21 B/op    2 allocs/op
BenchmarkScrollUpDown/200     16414399    73.58 ns/op    24 B/op    2 allocs/op

BenchmarkColor3BitF           13825933    83.02 ns/op    21 B/op    2 allocs/op
BenchmarkColor8BitF           13356769    92.91 ns/op    32 B/op    2 allocs/op
BenchmarkFullColorF            9991122   119.50 ns/op    40 B/op    2 allocs/op

PASS
ok   github.com/morikuni/aec    21.156s
```

### use strconv instead of fmt.Sprintf for ANSI construction

Improve performance

```
goos: darwin
goarch: arm64
pkg: github.com/morikuni/aec
cpu: Apple M3 Pro
                 │  before.txt  │              after.txt              │
                 │    sec/op    │   sec/op     vs base                │
Cursor/0            1.069n ± 5%   1.073n ± 1%        ~ (p=0.402 n=10)
Cursor/2            68.69n ± 2%   28.66n ± 2%  -58.27% (p=0.000 n=10)
Cursor/20           70.09n ± 2%   29.11n ± 2%  -58.47% (p=0.000 n=10)
Cursor/200          72.99n ± 3%   31.43n ± 1%  -56.94% (p=0.000 n=10)
Position/0,0        94.25n ± 3%   12.59n ± 2%  -86.64% (p=0.000 n=10)
Position/2,2        94.14n ± 2%   31.20n ± 2%  -66.86% (p=0.000 n=10)
Position/20,20      93.38n ± 3%   29.48n ± 2%  -68.42% (p=0.000 n=10)
Position/200,200    97.97n ± 2%   36.22n ± 7%  -63.03% (p=0.000 n=10)
Position/5,15       96.52n ± 3%   32.36n ± 2%  -66.47% (p=0.000 n=10)
ScrollUpDown/0      1.669n ± 8%   1.101n ± 3%  -34.05% (p=0.000 n=10)
ScrollUpDown/2      69.02n ± 2%   30.17n ± 1%  -56.30% (p=0.000 n=10)
ScrollUpDown/20     69.69n ± 2%   31.35n ± 2%  -55.02% (p=0.000 n=10)
ScrollUpDown/200    73.78n ± 1%   32.23n ± 5%  -56.32% (p=0.000 n=10)
Color3BitF          88.47n ± 5%   30.39n ± 3%  -65.66% (p=0.000 n=10)
Color8BitF          85.81n ± 8%   34.33n ± 1%  -59.99% (p=0.000 n=10)
FullColorF         113.50n ± 2%   44.19n ± 1%  -61.07% (p=0.000 n=10)
geomean             49.95n        19.87n       -60.22%

                 │  before.txt  │              after.txt               │
                 │     B/op     │    B/op     vs base                  │
Cursor/0           0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Cursor/2           20.00 ± 0%     20.00 ± 0%        ~ (p=1.000 n=10) ¹
Cursor/20          21.00 ± 0%     21.00 ± 0%        ~ (p=1.000 n=10) ¹
Cursor/200         24.00 ± 0%     24.00 ± 0%        ~ (p=1.000 n=10) ¹
Position/0,0       24.00 ± 0%     16.00 ± 0%  -33.33% (p=0.000 n=10)
Position/2,2       24.00 ± 0%     24.00 ± 0%        ~ (p=1.000 n=10) ¹
Position/20,20     24.00 ± 0%     24.00 ± 0%        ~ (p=1.000 n=10) ¹
Position/200,200   32.00 ± 0%     32.00 ± 0%        ~ (p=1.000 n=10) ¹
Position/5,15      24.00 ± 0%     24.00 ± 0%        ~ (p=1.000 n=10) ¹
ScrollUpDown/0     0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
ScrollUpDown/2     20.00 ± 0%     20.00 ± 0%        ~ (p=1.000 n=10) ¹
ScrollUpDown/20    21.00 ± 0%     21.00 ± 0%        ~ (p=1.000 n=10) ¹
ScrollUpDown/200   24.00 ± 0%     24.00 ± 0%        ~ (p=1.000 n=10) ¹
Color3BitF         21.00 ± 0%     21.00 ± 0%        ~ (p=1.000 n=10) ¹
Color8BitF         32.00 ± 0%     32.00 ± 0%        ~ (p=1.000 n=10) ¹
FullColorF         40.00 ± 0%     40.00 ± 0%        ~ (p=1.000 n=10) ¹
geomean                       ²                -2.50%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                 │  before.txt  │              after.txt               │
                 │  allocs/op   │ allocs/op   vs base                  │
Cursor/0           0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Cursor/2           2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=10) ¹
Cursor/20          2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=10) ¹
Cursor/200         2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=10) ¹
Position/0,0       2.000 ± 0%     1.000 ± 0%  -50.00% (p=0.000 n=10)
Position/2,2       2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=10) ¹
Position/20,20     2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=10) ¹
Position/200,200   2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=10) ¹
Position/5,15      2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=10) ¹
ScrollUpDown/0     0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
ScrollUpDown/2     2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=10) ¹
ScrollUpDown/20    2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=10) ¹
ScrollUpDown/200   2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=10) ¹
Color3BitF         2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=10) ¹
Color8BitF         2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=10) ¹
FullColorF         2.000 ± 0%     2.000 ± 0%        ~ (p=1.000 n=10) ¹
geomean                       ²                -4.24%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

