### PR TITLE
add benchmark tests

### DIFF
--- a/aec_bench_test.go
+++ b/aec_bench_test.go
@@ -1,0 +1,107 @@
+package aec_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/morikuni/aec"
+)
+
+// Representative benchmark for all single-parameter uint CSI generators:
+// Up, Down, Left, Right, NextLine, PreviousLine, Column, and EraseLine.
+func BenchmarkCursor(b *testing.B) {
+	var tests = []struct {
+		n uint
+	}{
+		{n: 0},   // 0,1 special case
+		{n: 1},   // 0,1 special case
+		{n: 2},   // 1 digit
+		{n: 20},  // 2 digit
+		{n: 200}, // 3 digits
+	}
+	for _, tc := range tests {
+		b.Run(fmt.Sprintf("%d", tc.n), func(b *testing.B) {
+			var a aec.ANSI
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				a = aec.Up(tc.n)
+			}
+			sinkANSI = a
+		})
+	}
+}
+
+// Covers the two-parameter uint CSI path used by [aec.Position].
+func BenchmarkPosition(b *testing.B) {
+	var tests = []struct {
+		row uint
+		col uint
+	}{
+		{row: 0, col: 0},     // 0,1 special case
+		{row: 1, col: 1},     // 0,1 special case
+		{row: 2, col: 2},     // 1 digit
+		{row: 20, col: 20},   // 2 digit
+		{row: 200, col: 200}, // 3 digits
+		{row: 5, col: 15},
+	}
+	for _, tc := range tests {
+		b.Run(fmt.Sprintf("%d,%d", tc.row, tc.col), func(b *testing.B) {
+			var a aec.ANSI
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				a = aec.Position(tc.row, tc.col)
+			}
+			sinkANSI = a
+		})
+	}
+}
+
+// Focused benchmark for [aec.EraseDisplay]. It exercises the small set of
+// common erase modes as well as arbitrary values, and is broadly representative
+// for [aec.EraseLine], which follows a similar implementation pattern.
+func BenchmarkEraseDisplay(b *testing.B) {
+	var tests = []struct {
+		mode aec.EraseMode
+	}{
+		{mode: 0},   // special case
+		{mode: 1},   // fixed known value
+		{mode: 2},   // fixed known value
+		{mode: 3},   // saved lines extension
+		{mode: 20},  // fallback path
+		{mode: 200}, // fallback path
+	}
+	for _, tc := range tests {
+		b.Run(fmt.Sprintf("%d", tc.mode), func(b *testing.B) {
+			var a aec.ANSI
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				a = aec.EraseDisplay(tc.mode)
+			}
+			sinkANSI = a
+		})
+	}
+}
+
+// Representative benchmark for all single-parameter int CSI
+// generators ([aec.ScrollUp], [aec.ScrollDown]).
+func BenchmarkScrollUpDown(b *testing.B) {
+	var tests = []struct {
+		n uint
+	}{
+		{n: 0},   // 0,1 special case
+		{n: 1},   // 0,1 special case
+		{n: 2},   // 1 digit
+		{n: 20},  // 2 digit
+		{n: 200}, // 3 digits
+	}
+	for _, tc := range tests {
+		b.Run(fmt.Sprintf("%d", tc.n), func(b *testing.B) {
+			var a aec.ANSI
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				a = aec.ScrollUp(int(tc.n))
+			}
+			sinkANSI = a
+		})
+	}
+}

--- a/builder_bench_test.go
+++ b/builder_bench_test.go
@@ -1,0 +1,37 @@
+package aec_test
+
+import (
+	"testing"
+
+	"github.com/morikuni/aec"
+)
+
+var sinkString string
+
+func BenchmarkBuilderFluent(b *testing.B) {
+	b.ReportAllocs()
+
+	var s string
+	for i := 0; i < b.N; i++ {
+		s = aec.EmptyBuilder.
+			Right(2).
+			RGB8BitF(128, 255, 64).
+			RedB().
+			Bold().
+			ANSI.
+			Apply("Hello World")
+	}
+	sinkString = s
+}
+
+func BenchmarkBuilderWith(b *testing.B) {
+	b.ReportAllocs()
+
+	var ansi aec.ANSI
+	for i := 0; i < b.N; i++ {
+		ansi = aec.NewBuilder(aec.Up(2)).
+			With(aec.Column(10), aec.Bold, aec.RedF).
+			ANSI
+	}
+	sinkANSI = ansi
+}

--- a/sgr_bench_test.go
+++ b/sgr_bench_test.go
@@ -1,0 +1,39 @@
+package aec_test
+
+import (
+	"testing"
+
+	"github.com/morikuni/aec"
+)
+
+var sinkANSI aec.ANSI // used in benchmarks to avoid compiler optimizations
+
+func BenchmarkColor3BitF(b *testing.B) {
+	b.ReportAllocs()
+
+	var a aec.ANSI
+	for i := 0; i < b.N; i++ {
+		a = aec.Color3BitF(3)
+	}
+	sinkANSI = a
+}
+
+func BenchmarkColor8BitF(b *testing.B) {
+	b.ReportAllocs()
+
+	var a aec.ANSI
+	for i := 0; i < b.N; i++ {
+		a = aec.Color8BitF(128)
+	}
+	sinkANSI = a
+}
+
+func BenchmarkFullColorF(b *testing.B) {
+	b.ReportAllocs()
+
+	var a aec.ANSI
+	for i := 0; i < b.N; i++ {
+		a = aec.FullColorF(255, 128, 0)
+	}
+	sinkANSI = a
+}


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/morikuni/aec
cpu: Apple M3 Pro

BenchmarkCursor/0           1000000000     1.082 ns/op     0 B/op      0 allocs/op
BenchmarkCursor/1           19155609       68.19 ns/op     20 B/op     2 allocs/op
BenchmarkCursor/2           18512708       70.56 ns/op     20 B/op     2 allocs/op
BenchmarkCursor/20          17439208       71.64 ns/op     21 B/op     2 allocs/op
BenchmarkCursor/200         15858112       72.50 ns/op     24 B/op     2 allocs/op

BenchmarkPosition/0,0       13222344       92.66 ns/op     24 B/op     2 allocs/op
BenchmarkPosition/1,1       13894000       92.44 ns/op     24 B/op     2 allocs/op
BenchmarkPosition/2,2       12211875       94.83 ns/op     24 B/op     2 allocs/op
BenchmarkPosition/20,20     12199171       95.88 ns/op     24 B/op     2 allocs/op
BenchmarkPosition/200,200   12728629       100.7 ns/op     32 B/op     2 allocs/op
BenchmarkPosition/5,15      12093298       96.45 ns/op     24 B/op     2 allocs/op

BenchmarkEraseDisplay/0     15354889       84.39 ns/op     20 B/op     2 allocs/op
BenchmarkEraseDisplay/1     14803665       84.80 ns/op     20 B/op     2 allocs/op
BenchmarkEraseDisplay/2     14292037       81.21 ns/op     20 B/op     2 allocs/op
BenchmarkEraseDisplay/3     14696929       73.16 ns/op     20 B/op     2 allocs/op
BenchmarkEraseDisplay/20    16980390       73.61 ns/op     21 B/op     2 allocs/op
BenchmarkEraseDisplay/200   13056309       82.76 ns/op     24 B/op     2 allocs/op

BenchmarkScrollUpDown/0     1000000000     1.101 ns/op     0 B/op      0 allocs/op
BenchmarkScrollUpDown/1     18142771       68.53 ns/op     20 B/op     2 allocs/op
BenchmarkScrollUpDown/2     18104678       67.67 ns/op     20 B/op     2 allocs/op
BenchmarkScrollUpDown/20    16923913       70.32 ns/op     21 B/op     2 allocs/op
BenchmarkScrollUpDown/200   16939790       70.74 ns/op     24 B/op     2 allocs/op

BenchmarkBuilderFluent      1806829        671.0 ns/op     560 B/op    29 allocs/op
BenchmarkBuilderWith        3688992        326.4 ns/op     312 B/op    12 allocs/op

BenchmarkColor3BitF         13278399       87.57 ns/op     21 B/op     2 allocs/op
BenchmarkColor8BitF         13405442       93.59 ns/op     32 B/op     2 allocs/op
BenchmarkFullColorF         9992067        120.7 ns/op     40 B/op     2 allocs/op

PASS
ok   github.com/morikuni/aec   35.885s
```